### PR TITLE
Update Test Case content in JAMA

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,9 +61,14 @@ The Allure test reports to be processed by this script as well as the actions to
 			"inputFolderPath": "project2/input",
 			"outputFolderPath": "project2/output",
 			"saveAsPDF": true,
-			"uploadToJAMA": false
+			"uploadToJAMA": true
 		}
-	]
+	],
+    "jamaConfig": {
+        "username": "",
+        "password": "",
+        "server": "https://<server>/rest/v1"
+    } 
 }
 ```
 
@@ -87,4 +92,4 @@ This feature is enabled by setting to true the `saveAsPDF` attribute of the proj
 
 ### Automated upload of test results to JAMA contour
 
-`TBD`
+This feature is enabled by setting to true the `uploadToJAMA` attribute of the projects defined into the configuration file. Then, the script will load all the Allure reports found under the `inputFolderPath` folder and updated the related test cases in JAMA. The JAMA credentials should be set at `jamaConfig` object.

--- a/src/model/configuration.model.ts
+++ b/src/model/configuration.model.ts
@@ -3,6 +3,7 @@ export interface Configuration
 {
     website: string;
     projects: Project[];
+    jamaConfig: JamaConfig
 }
 
 export interface Project
@@ -12,4 +13,11 @@ export interface Project
     outputFolderPath: string;
     saveAsPDF: boolean;
     uploadToJAMA: boolean;
+}
+
+export interface JamaConfig 
+{
+    username: string;
+    password: string;
+    server: string;
 }

--- a/src/widgets/app-header.widget.ts
+++ b/src/widgets/app-header.widget.ts
@@ -1,10 +1,21 @@
 import * as puppeteer from "puppeteer";
 
+const baseLocator = 'app-navbar button';
 
 export class ApplicationHeader
-{
+{      
     public static async hideSummary(page: puppeteer.Page): Promise<void>
     {
-        await page.click("app-navbar button .fa-table");
+        await page.click(`${baseLocator} .fa-table`);
+    }
+
+    public static async openLoginDialog(page: puppeteer.Page): Promise<void>
+    {
+        await page.click(`${baseLocator} .fa-user`)
+    }
+
+    public static async openUploadDialog(page: puppeteer.Page): Promise<void> 
+    {
+        await page.click(`${baseLocator} .fa-upload`)
     }
 }

--- a/src/widgets/index.ts
+++ b/src/widgets/index.ts
@@ -1,3 +1,5 @@
 export * from "./app-header.widget";
 export * from "./drop-zone.widget";
 export * from "./html-report.widget";
+export * from "./login-dialog.widget";
+export * from "./upload-dialog.widget";

--- a/src/widgets/login-dialog.widget.ts
+++ b/src/widgets/login-dialog.widget.ts
@@ -1,0 +1,24 @@
+import * as puppeteer from "puppeteer";
+
+
+export class LoginDialog
+{
+    public static async login(page: puppeteer.Page, username: string, password: string, url:string): Promise<void>
+    {        
+        await this.clearInput(page, "#username")
+        await page.type("#username", username)
+
+        await this.clearInput(page, "#password")
+        await page.type("#password", password)
+
+        await this.clearInput(page, "#server")
+        await page.type("#server", url)
+
+        await page.click("button.btn.ml-auto")
+    }
+
+    private static async clearInput(page: puppeteer.Page, locator:string) {
+        await page.click(locator, { clickCount: 3 }); // Select all
+        await page.keyboard.press('Backspace');
+    }
+}

--- a/src/widgets/upload-dialog.widget.ts
+++ b/src/widgets/upload-dialog.widget.ts
@@ -1,0 +1,47 @@
+import * as puppeteer from "puppeteer";
+
+
+export class UploadDialog
+{   
+    public static async openProjectDialog(page: puppeteer.Page): Promise<void>
+    {        
+        await page.click("div.slab-dropdown-toogle button.slab-combo-button")
+    }
+
+    public static async selectProject(page: puppeteer.Page, project: string): Promise<void>
+    {
+        const projectItem = await page.evaluateHandle((projectName) => {
+            return Array.from(document.querySelectorAll('div[role="gridcell"]')).find(
+                el => el.textContent?.trim() === projectName
+            );
+        }, project);
+
+        // Check if the project item exists and cast it to ElementHandle<Element>
+        if (projectItem) {
+            const element = await projectItem.asElement() as puppeteer.ElementHandle<Element>;
+            if (element) {
+                await element.click();
+            } else {
+                console.log('The item is not an Element.');
+            }
+        } else {
+            console.log('Project item not found.');
+        }
+    }
+
+    public static async clickUpdateTests(page: puppeteer.Page): Promise<void>
+    {
+        await page.click('button.btn.mr-0')
+    }
+
+    public static async checkUploadStatus(page: puppeteer.Page): Promise<void>
+    {   
+        try {   
+            await page.waitForSelector('[aria-label="Test cases description and steps updated"]');
+        }
+        catch(error) {
+            console.error('Confirmation Toast not found.');
+            throw error;
+        }        
+    }
+}

--- a/test/configuration/configuration-all.json
+++ b/test/configuration/configuration-all.json
@@ -15,5 +15,10 @@
 			"saveAsPDF": true,
 			"uploadToJAMA": false
 		}
-	]
+	],
+    "jamaConfig": {
+        "username": "",
+        "password": "",
+        "server": "https://<server>/rest/v1"
+    }  
 }

--- a/test/configuration/configuration-json.json
+++ b/test/configuration/configuration-json.json
@@ -8,5 +8,10 @@
 			"saveAsPDF": true,
 			"uploadToJAMA": false
 		}
-	]
+	],
+    "jamaConfig": {
+        "username": "",
+        "password": "",
+        "server": "https://<server>/rest/v1"
+    }  
 }

--- a/test/configuration/configuration-xml.json
+++ b/test/configuration/configuration-xml.json
@@ -8,5 +8,10 @@
 			"saveAsPDF": true,
 			"uploadToJAMA": false
 		}
-	]
+	],
+    "jamaConfig": {
+        "username": "",
+        "password": "",
+        "server": "https://<server>/rest/v1"
+    }  
 }


### PR DESCRIPTION
This feature is enabled by setting to true the `uploadToJAMA` attribute of the projects defined into the configuration file. Then, the script will load all the Allure reports found under the `inputFolderPath` folder and updated the related test cases in JAMA. The JAMA credentials should be set at `jamaConfig` object.


https://github.com/user-attachments/assets/fd9db69b-bb80-4593-a435-d0b91e6092e7

